### PR TITLE
Adds compatibility with openjdk-11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ repositories {
 }
 
 dependencies {
+    compile 'javax.xml.bind:jaxb-api:2.3.0'
+    compile 'javax.activation:activation:1.1'
+    compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
     compile "org.sbml.jsbml:jsbml:1.4"
     compile "de.zbit:SysBio:1390"
     compile "org.xerial:sqlite-jdbc:3.21.0"


### PR DESCRIPTION
Add the following dependency in `build.gradle`:
```
compile 'javax.xml.bind:jaxb-api:2.3.0'
compile 'javax.activation:activation:1.1'
compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
```